### PR TITLE
API client class v1.1.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## UniFi Controller API client class
 
-A PHP class that provides access to Ubiquiti's [**UniFi Network Controller**](https://unifi-network.ui.com/) API, versions 4.X.X, 5.X.X and 6.0.X of the UniFi Network Controller software are supported (version 6.0.37 has been confirmed to work) as well as UbiOS-based controllers (version 5.12.59 has been confirmed to work). This class is used by our API browser tool which can be found [here](https://github.com/Art-of-WiFi/UniFi-API-browser).
+A PHP class that provides access to Ubiquiti's [**UniFi Network Controller**](https://unifi-network.ui.com/) API, versions 4.X.X, 5.X.X and 6.0.X of the UniFi Network Controller software are supported (version 6.0.42 has been confirmed to work) as well as UniFi OS-based controllers (version 5.12.59 has been confirmed to work). This class is used by our API browser tool which can be found [here](https://github.com/Art-of-WiFi/UniFi-API-browser).
 
 The package can be installed manually or by using composer/[packagist](https://packagist.org/packages/art-of-wifi/unifi-api-client) for easy inclusion in your projects.
 
@@ -11,11 +11,11 @@ The package can be installed manually or by using composer/[packagist](https://p
 - you must use **local accounts**, not UniFi Cloud accounts, to access the UniFi Controller API through this class
 
 
-## UbiOS Support
+## UniFi OS Support
 
-Support for UbiOS-based controllers (UniFi Dream Machine Pro) has been added as of version 1.1.47. The class automatically detects UbiOS devices and adjusts URLs and several functions/methods accordingly. If your own code applies strict validation of the URL that is passed to the constructor, please adapt your logic to allow URLs without a port suffix when dealing with a UbiOS-based controller.
+Support for UniFi OS-based controllers (UniFi Dream Machine Pro) has been added as of version 1.1.47. The class automatically detects UniFi OS devices and adjusts URLs and several functions/methods accordingly. If your own code applies strict validation of the URL that is passed to the constructor, please adapt your logic to allow URLs without a port suffix when dealing with a UniFi OS-based controller.
 
-Please test all methods you plan on using thoroughly before using the API Client with UbiOS devices in a production environment.
+Please test all methods you plan on using thoroughly before using the API Client with UniFi OS devices in a production environment.
 
 ## Installation
 
@@ -300,7 +300,7 @@ This class is based on the initial work by the following developers:
 
 and the API as published by Ubiquiti:
 
-- https://dl.ui.com/unifi/5.12.35/unifi_sh_api
+- https://dl.ui.com/unifi/6.0.41/unifi_sh_api
 
 ## Important Disclaimer
 


### PR DESCRIPTION
- changed references to *UbiOS* back to *UniFi OS*
- removed capitalization from all header strings (per RFC, header fields are case-insensitive: https://tools.ietf.org/html/rfc7230#section-3.2)
- removed charset parameter from headers (not required per RFC)
- added x-csrf-token header to all requests except GET when talking to UniFi OS-based controllers, thanks go to @paciks for raising #86